### PR TITLE
Changed dev script to build with watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "mwmbl-crawler-extension",
   "version": "0.0.0",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "dev": "vite build --watch",
+    "build": "vite build"
   },
   "devDependencies": {
     "vite": "^2.7.2"


### PR DESCRIPTION
Cleaned up `package.json` and changed the `dev` script to build in watch mode.

Thanks to that change, there will be no need to re-build manually during development.