### PR TITLE
Internationalization

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,17 +1,17 @@
 {
-	"webextensionName": {
+	"manifest_name": {
 		"description": "Web-extension name.",
 		"message": "MWMBL Web Crawler"
 	},
-	"webextensionShortName": {
+	"manifest_shortName": {
 		"description": "Web-extension short name.",
 		"message": "MWMBL Crawl"
 	},
-	"webextensionDescription": {
+	"manifest_description": {
 		"description": "Web-extension description.",
 		"message": "Help crawl the web to build a non-profit search engine."
 	},
-	"browserActionDefaultTitle": {
+	"manifest_actionTitle": {
 		"description": "Toolbar button title.",
 		"message": "MWMBL Web Crawler"
 	}

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,0 +1,18 @@
+{
+	"webextensionName": {
+		"description": "Web-extension name.",
+		"message": "MWMBL Web Crawler"
+	},
+	"webextensionShortName": {
+		"description": "Web-extension short name.",
+		"message": "MWMBL Crawl"
+	},
+	"webextensionDescription": {
+		"description": "Web-extension description.",
+		"message": "Help crawl the web to build a non-profit search engine."
+	},
+	"browserActionDefaultTitle": {
+		"description": "Toolbar button title.",
+		"message": "MWMBL Web Crawler"
+	}
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,10 @@
 {
-  "name": "Mwmbl Web Crawler",
-  "description": "Help crawl the web to build a non-profit search engine",
+  "name": "__MSG_webextensionName__",
   "version": "0.4.4",
   "manifest_version": 2,
+  "short_name": "__MSG_webextensionShortName__",
+  "default_locale": "en",
+  "description": "__MSG_webextensionDescription__",
   "background": {
     "scripts": ["./assets/background.js"],
     "persistent": true
@@ -16,7 +18,7 @@
   },
   "browser_action": {
     "default_icon": "./mwmbl32.png",
-    "default_title": "Mwmbl - Web Crawler",
+    "default_title": "__MSG_browserActionDefaultTitle__",
     "default_popup": "./popup/index.html"
   }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,10 +1,10 @@
 {
-  "name": "__MSG_webextensionName__",
+  "name": "__MSG_manifest_name__",
   "version": "0.4.4",
   "manifest_version": 2,
-  "short_name": "__MSG_webextensionShortName__",
+  "short_name": "__MSG_manifest_shortName__",
   "default_locale": "en",
-  "description": "__MSG_webextensionDescription__",
+  "description": "__MSG_manifest_description__",
   "background": {
     "scripts": ["./assets/background.js"],
     "persistent": true
@@ -18,7 +18,7 @@
   },
   "browser_action": {
     "default_icon": "./mwmbl32.png",
-    "default_title": "__MSG_browserActionDefaultTitle__",
+    "default_title": "__MSG_manifest_actionTitle__",
     "default_popup": "./popup/index.html"
   }
 }


### PR DESCRIPTION
Added internationalization.

With this others will be able to translate the extension into languages other than English.

To add a new translation a person would do the following:
1. Add folder for new language in the `_locales` directory
   - Example: `de` for German, `fr_FR` for French
2. Copy `_locales/en/messages.json` to the directory created in step 1
   - Translate the "description" and "message" sections into the desired language