### PR TITLE
Add Mirror to Codeberg workflow

### DIFF
--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -1,0 +1,19 @@
+# Sync repo to the Codeberg mirror
+name: Codeberg Mirror Sync
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch: # Manual dispatch
+  schedule:
+    - cron: "0 */6 * * *"
+jobs:
+  codeberg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url: "git@codeberg.org:mwmbl/crawler-extension.git"
+          ssh_private_key: ${{ secrets.CODEBERG_SSH }}


### PR DESCRIPTION
This pull request adds a mirroring workflow pointing to codeberg.org/mwmbl/$REPONAME